### PR TITLE
redux, canvas setup; color, size interaction ref added

### DIFF
--- a/src/components/Board/index.js
+++ b/src/components/Board/index.js
@@ -1,0 +1,24 @@
+import { useRef, useEffect } from "react";
+const Board = () => {
+     const canvasRef = useRef(null);
+
+     useEffect(() => {
+          
+          if (!canvasRef.current) return
+          const canvas = canvasRef.current
+          const context = canvas.getContext('2d');
+          
+          // when mounting
+          canvas.width = window.innerWidth;
+          canvas.height = window.innerheight;
+     }, []);
+     
+
+     return (
+          <>
+               <canvas ref={canvasRef}></canvas>
+          </>
+     )
+}
+
+export default Board;

--- a/src/components/Board/index.js
+++ b/src/components/Board/index.js
@@ -1,7 +1,11 @@
 import { useRef, useEffect } from "react";
+import { useSelector, useDispatch } from 'react-redux';
+
 const Board = () => {
      const canvasRef = useRef(null);
-
+     const activeMenuItem = useSelector((state) => state.menu.activeMenuItem);
+     const { color, size } = useSelector((state) => state.toolbox[activeMenuItem]);
+     // console.log(color, size);
      useEffect(() => {
           
           if (!canvasRef.current) return

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -1,12 +1,13 @@
 import styles from './index.module.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPencil, faEraser, faRotateLeft, faRotateRight, faFileArrowDown } from '@fortawesome/free-solid-svg-icons'
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { MENU_ITEMS } from '@/utility/constants';
 import { menuItemClick, actionItemClick } from './../../slice/menuSlice';
+import cx from 'classnames';
 const Menu = () => {
-     
      const dispatch = useDispatch();
+     const activeMenuItem = useSelector((state) => state.menu.activeMenuItem);
 
      const handleMenuClick = (itemName) => {
           dispatch(menuItemClick(itemName));
@@ -16,20 +17,20 @@ const Menu = () => {
           <>
                <div className={styles.menuContainer}>
                     {/* visual states */}
-                    <div className={styles.iconWrapper} onClick={() => handleMenuClick(MENU_ITEMS.PENCIL)}>
+                    <div className={cx(styles.iconWrapper, { [styles.active]: activeMenuItem === MENU_ITEMS.PENCIL })} onClick={() => handleMenuClick(MENU_ITEMS.PENCIL)}>
                          <FontAwesomeIcon icon={faPencil} className={styles.actionIcon} />
                     </div>
-                    <div className={styles.iconWrapper} onClick={() => handleMenuClick(MENU_ITEMS.ERASER)} >
+                    <div className={cx(styles.iconWrapper, { [styles.active]: activeMenuItem === MENU_ITEMS.ERASER })} onClick={() => handleMenuClick(MENU_ITEMS.ERASER)} >
                          <FontAwesomeIcon icon={faEraser} className={styles.actionIcon} />
                     </div>
                     {/* actionable states */}
-                    <div className={styles.iconWrapper} onClick={() => handleMenuClick(MENU_ITEMS.UNDO)}>
+                    <div className={cx(styles.iconWrapper, { [styles.active]: activeMenuItem === MENU_ITEMS.UNDO })} onClick={() => handleMenuClick(MENU_ITEMS.UNDO)}>
                          <FontAwesomeIcon icon={faRotateLeft} className={styles.actionIcon} />
                     </div>
-                    <div className={styles.iconWrapper} onClick={() => handleMenuClick(MENU_ITEMS.REDO)}>
+                    <div className={cx(styles.iconWrapper, { [styles.active]: activeMenuItem === MENU_ITEMS.REDO })} onClick={() => handleMenuClick(MENU_ITEMS.REDO)}>
                          <FontAwesomeIcon icon={faRotateRight} className={styles.actionIcon} />
                     </div>
-                    <div className={styles.iconWrapper} onClick={() => handleMenuClick(MENU_ITEMS.DOWNLOAD)}>
+                    <div className={cx(styles.iconWrapper, { [styles.active]: activeMenuItem === MENU_ITEMS.DOWNLOAD })} onClick={() => handleMenuClick(MENU_ITEMS.DOWNLOAD)}>
                          <FontAwesomeIcon icon={faFileArrowDown} className={styles.actionIcon} />
                     </div>
                </div>

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -1,23 +1,35 @@
 import styles from './index.module.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPencil, faEraser, faRotateLeft, faRotateRight, faFileArrowDown } from '@fortawesome/free-solid-svg-icons'
+import { useDispatch } from 'react-redux';
+import { MENU_ITEMS } from '@/utility/constants';
+import { menuItemClick, actionItemClick } from './../../slice/menuSlice';
 const Menu = () => {
+     
+     const dispatch = useDispatch();
+
+     const handleMenuClick = (itemName) => {
+          dispatch(menuItemClick(itemName));
+     }
+
      return (
           <>
                <div className={styles.menuContainer}>
-                    <div className={styles.iconWrapper}>
+                    {/* visual states */}
+                    <div className={styles.iconWrapper} onClick={() => handleMenuClick(MENU_ITEMS.PENCIL)}>
                          <FontAwesomeIcon icon={faPencil} className={styles.actionIcon} />
                     </div>
-                    <div className={styles.iconWrapper}>
+                    <div className={styles.iconWrapper} onClick={() => handleMenuClick(MENU_ITEMS.ERASER)} >
                          <FontAwesomeIcon icon={faEraser} className={styles.actionIcon} />
                     </div>
-                    <div className={styles.iconWrapper}>
+                    {/* actionable states */}
+                    <div className={styles.iconWrapper} onClick={() => handleMenuClick(MENU_ITEMS.UNDO)}>
                          <FontAwesomeIcon icon={faRotateLeft} className={styles.actionIcon} />
                     </div>
-                    <div className={styles.iconWrapper}>
+                    <div className={styles.iconWrapper} onClick={() => handleMenuClick(MENU_ITEMS.REDO)}>
                          <FontAwesomeIcon icon={faRotateRight} className={styles.actionIcon} />
                     </div>
-                    <div className={styles.iconWrapper}>
+                    <div className={styles.iconWrapper} onClick={() => handleMenuClick(MENU_ITEMS.DOWNLOAD)}>
                          <FontAwesomeIcon icon={faFileArrowDown} className={styles.actionIcon} />
                     </div>
                </div>

--- a/src/components/Menu/index.module.css
+++ b/src/components/Menu/index.module.css
@@ -8,7 +8,7 @@
      .iconWrapper {
           @apply cursor-pointer flex justify-center items-center h-10 w-10 rounded-md;
 
-          &:hover, &:active{
+          &:hover, &.active{
                background-color: theme('colors.text2')
           }
 

--- a/src/components/Toolbox/index.js
+++ b/src/components/Toolbox/index.js
@@ -2,19 +2,22 @@ import styles from './index.module.css';
 import { COLORS, MENU_ITEMS } from './../../utility/constants.js';
 import { useSelector, useDispatch } from 'react-redux';
 import { changeBrushSize, changeColor } from '@/slice/toolBoxSlice';
+import cx from 'classnames';
+
 
 const Toolbox = () => {
      const dispatch = useDispatch();
      const activeMenuItem = useSelector((state) => state.menu.activeMenuItem);
      const showColorStrokes = activeMenuItem === MENU_ITEMS.PENCIL;
      const showBrush = activeMenuItem === MENU_ITEMS.PENCIL || activeMenuItem === MENU_ITEMS.ERASER;
+     const { color } = useSelector((state) => state.toolbox[activeMenuItem]);
 
      const updateBrushSize = (e) => {
           dispatch(changeBrushSize({ item: activeMenuItem, size: e.target.value }))
      };
 
      const updateColor = (newColor) => {
-          dispatch(changeColor({item: activeMenuItem, color: newColor }))
+          dispatch(changeColor({ item: activeMenuItem, color: newColor }))
      }
 
      return (
@@ -25,12 +28,12 @@ const Toolbox = () => {
                          <div className={styles.toolItem}>
                               <h4 className={styles.toolText}>Stroke Color</h4>
                               <div className={styles.itemContainer}>
-                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.BLACK }} onClick={()=> updateColor(COLORS.BLACK)} />
-                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.RED }} onClick={() => updateColor(COLORS.RED)} />
-                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.GREEN }} onClick={()=> updateColor(COLORS.GREEN)}/>
-                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.BLUE }} onClick={() => updateColor(COLORS.BLUE)} />
-                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.ORANGE }} onClick={() => updateColor(COLORS.ORANGE)} />
-                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.YELLOW }} onClick={() => updateColor(COLORS.YELLOW)} />
+                                   <div className={cx(styles.colorBox, { [styles.active]: color === COLORS.BLACK })} style={{ backgroundColor: COLORS.BLACK }} onClick={() => updateColor(COLORS.BLACK)} />
+                                   <div className={cx(styles.colorBox, { [styles.active]: color === COLORS.RED })} style={{ backgroundColor: COLORS.RED }} onClick={() => updateColor(COLORS.RED)} />
+                                   <div className={cx(styles.colorBox, { [styles.active]: color === COLORS.GREEN })} style={{ backgroundColor: COLORS.GREEN }} onClick={() => updateColor(COLORS.GREEN)} />
+                                   <div className={cx(styles.colorBox, { [styles.active]: color === COLORS.BLUE })} style={{ backgroundColor: COLORS.BLUE }} onClick={() => updateColor(COLORS.BLUE)} />
+                                   <div className={cx(styles.colorBox, { [styles.active]: color === COLORS.ORANGE })} style={{ backgroundColor: COLORS.ORANGE }} onClick={() => updateColor(COLORS.ORANGE)} />
+                                   <div className={cx(styles.colorBox, { [styles.active]: color === COLORS.YELLOW })} style={{ backgroundColor: COLORS.YELLOW }} onClick={() => updateColor(COLORS.YELLOW)} />
                               </div>
                          </div>
                     }

--- a/src/components/Toolbox/index.js
+++ b/src/components/Toolbox/index.js
@@ -1,35 +1,41 @@
 import styles from './index.module.css';
-import { COLORS } from './../../utility/constants.js';
+import { COLORS, MENU_ITEMS } from './../../utility/constants.js';
 import { useSelector } from 'react-redux';
 
 const Toolbox = () => {
 
      const activeMenuItem = useSelector((state)=>state.menu.activeMenuItem);
-
+     const showColorStrokes = activeMenuItem === MENU_ITEMS.PENCIL;
+     const showBrush = activeMenuItem === MENU_ITEMS.PENCIL || activeMenuItem === MENU_ITEMS.ERASER;
      const updateBrushSize = () => { };
      return (
           <>
                <div className={styles.toolboxContainer}>
-                    <div className={styles.toolItem}>
-                         <h4 className={styles.toolText}>Stroke Color</h4>
-                         <div className={styles.itemContainer}>
-                              <div className={styles.colorBox} style={{ backgroundColor: COLORS.BLACK }} />
-                              <div className={styles.colorBox} style={{ backgroundColor: COLORS.RED }} />
-                              <div className={styles.colorBox} style={{ backgroundColor: COLORS.GREEN }} />
-                              <div className={styles.colorBox} style={{ backgroundColor: COLORS.BLUE }} />
-                              <div className={styles.colorBox} style={{ backgroundColor: COLORS.ORANGE }} />
-                              <div className={styles.colorBox} style={{ backgroundColor: COLORS.YELLOW }} />
-                              <div className={styles.colorBox} style={{ backgroundColor: COLORS.WHITE }} />
+                    {
+                         showColorStrokes && 
+                         <div className={styles.toolItem}>
+                              <h4 className={styles.toolText}>Stroke Color</h4>
+                              <div className={styles.itemContainer}>
+                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.BLACK }} />
+                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.RED }} />
+                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.GREEN }} />
+                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.BLUE }} />
+                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.ORANGE }} />
+                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.YELLOW }} />
+                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.WHITE }} />
+                              </div>
                          </div>
-                    </div>
-
-                    <div className={styles.toolItem}>
-                         <h4 className={styles.toolText}>Brush Size</h4>
-                         {/* <h2>{activeMenuItem}</h2> */}
-                         <div className={styles.itemContainer}>
-                              <input type='range' min={1} max={10} step={1} onChange={updateBrushSize} />
+                    }
+                    {
+                         showBrush && 
+                         <div className={styles.toolItem}>
+                              <h4 className={styles.toolText}>Brush Size</h4>
+                              {/* <h2>{activeMenuItem}</h2> */}
+                              <div className={styles.itemContainer}>
+                                   <input type='range' min={1} max={10} step={1} onChange={updateBrushSize} />
+                              </div>
                          </div>
-                    </div>
+                    }
                </div>
           </>
      )

--- a/src/components/Toolbox/index.js
+++ b/src/components/Toolbox/index.js
@@ -1,33 +1,41 @@
 import styles from './index.module.css';
 import { COLORS, MENU_ITEMS } from './../../utility/constants.js';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+import { changeBrushSize, changeColor } from '@/slice/toolBoxSlice';
 
 const Toolbox = () => {
-
-     const activeMenuItem = useSelector((state)=>state.menu.activeMenuItem);
+     const dispatch = useDispatch();
+     const activeMenuItem = useSelector((state) => state.menu.activeMenuItem);
      const showColorStrokes = activeMenuItem === MENU_ITEMS.PENCIL;
      const showBrush = activeMenuItem === MENU_ITEMS.PENCIL || activeMenuItem === MENU_ITEMS.ERASER;
-     const updateBrushSize = () => { };
+
+     const updateBrushSize = (e) => {
+          dispatch(changeBrushSize({ item: activeMenuItem, size: e.target.value }))
+     };
+
+     const updateColor = (newColor) => {
+          dispatch(changeColor({item: activeMenuItem, color: newColor }))
+     }
+
      return (
           <>
                <div className={styles.toolboxContainer}>
                     {
-                         showColorStrokes && 
+                         showColorStrokes &&
                          <div className={styles.toolItem}>
                               <h4 className={styles.toolText}>Stroke Color</h4>
                               <div className={styles.itemContainer}>
-                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.BLACK }} />
-                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.RED }} />
-                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.GREEN }} />
-                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.BLUE }} />
-                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.ORANGE }} />
-                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.YELLOW }} />
-                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.WHITE }} />
+                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.BLACK }} onClick={()=> updateColor(COLORS.BLACK)} />
+                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.RED }} onClick={() => updateColor(COLORS.RED)} />
+                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.GREEN }} onClick={()=> updateColor(COLORS.GREEN)}/>
+                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.BLUE }} onClick={() => updateColor(COLORS.BLUE)} />
+                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.ORANGE }} onClick={() => updateColor(COLORS.ORANGE)} />
+                                   <div className={styles.colorBox} style={{ backgroundColor: COLORS.YELLOW }} onClick={() => updateColor(COLORS.YELLOW)} />
                               </div>
                          </div>
                     }
                     {
-                         showBrush && 
+                         showBrush &&
                          <div className={styles.toolItem}>
                               <h4 className={styles.toolText}>Brush Size</h4>
                               {/* <h2>{activeMenuItem}</h2> */}

--- a/src/components/Toolbox/index.js
+++ b/src/components/Toolbox/index.js
@@ -1,7 +1,11 @@
 import styles from './index.module.css';
 import { COLORS } from './../../utility/constants.js';
+import { useSelector } from 'react-redux';
 
 const Toolbox = () => {
+
+     const activeMenuItem = useSelector((state)=>state.menu.activeMenuItem);
+
      const updateBrushSize = () => { };
      return (
           <>
@@ -21,6 +25,7 @@ const Toolbox = () => {
 
                     <div className={styles.toolItem}>
                          <h4 className={styles.toolText}>Brush Size</h4>
+                         {/* <h2>{activeMenuItem}</h2> */}
                          <div className={styles.itemContainer}>
                               <input type='range' min={1} max={10} step={1} onChange={updateBrushSize} />
                          </div>

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,5 +1,9 @@
 import '@/styles/globals.css'
+import { Provider } from 'react-redux';
+import { store } from '@/store';
 
 export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return <Provider store={store}>
+    <Component {...pageProps} />
+  </Provider>
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,10 +1,12 @@
 import Menu from "@/components/Menu"
 import Toolbox from "@/components/Toolbox"
+import Board from "@/components/Board"
 export default function Home() {
   return (
     <>
       <Menu />
       <Toolbox />
+      <Board/>
     </>
   )
 }

--- a/src/slice/menuSlice.js
+++ b/src/slice/menuSlice.js
@@ -1,0 +1,24 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { MENU_ITEMS } from '@/utility/constants';
+
+const initialState = {
+     activeMenuItem: MENU_ITEMS.PENCIL,
+     actionMenuItem: null
+}
+
+export const menuSlice = createSlice({
+     name: "menu",
+     initialState,
+     reducers: {
+          menuItemClick: (state, action) => {
+               state.activeMenuItem = action.payload;
+          },
+          actionItemClick: (state, action) => {
+               state.actionMenuItem = action.payload;
+          }
+     }
+})
+
+export const { menuItemClick, actionItemClick } = menuSlice.actions
+
+export default menuSlice.reducer

--- a/src/slice/toolBoxSlice.js
+++ b/src/slice/toolBoxSlice.js
@@ -1,0 +1,33 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { MENU_ITEMS, COLORS } from '@/utility/constants';
+
+const initialState = {
+     [MENU_ITEMS.PENCIL]: {
+          color: COLORS.BLACK,
+          size: 3,
+     },
+     [MENU_ITEMS.ERASER]: {
+          color: COLORS.WHITE,
+          size: 3,
+     },
+     [MENU_ITEMS.UNDO]: {},
+     [MENU_ITEMS.REDO]: {},
+     [MENU_ITEMS.DOWNLOAD]: {},
+}
+
+export const toolBoxSlice = createSlice({
+     name: 'toolbox',
+     initialState,
+     reducers: {
+          changeColor: (state, action) => {
+               state[action.payload.item].color = action.payload.color
+          },
+          changeBrushSize: (state, action) => {
+               state[action.payload.item].size = action.payload.size
+          }
+     }
+})
+
+export const { changeColor, changeBrushSize } = toolBoxSlice.actions;
+
+export default toolBoxSlice.reducer;

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,8 @@
+import { configureStore } from "@reduxjs/toolkit";
+import MenuReducer from './slice/menuSlice';
+
+export const store = configureStore({
+     reducer: {
+          menu : MenuReducer
+     }
+})

--- a/src/store.js
+++ b/src/store.js
@@ -1,8 +1,10 @@
 import { configureStore } from "@reduxjs/toolkit";
 import MenuReducer from './slice/menuSlice';
+import ToolboxReducer from './slice/toolBoxSlice';
 
 export const store = configureStore({
      reducer: {
-          menu : MenuReducer
+          menu : MenuReducer,
+          toolbox: ToolboxReducer,
      }
 })


### PR DESCRIPTION
- [board and canvas setup](https://github.com/vaibhav18matere/sketchbook/commit/05533c88fb90d64327d1e265281f1ad749bbfca0)
- [setup redux store](https://github.com/vaibhav18matere/sketchbook/commit/58cde5064751eea0d690d41f10a6df600de42d48)
- [conditionally show brush or stroke](https://github.com/vaibhav18matere/sketchbook/commit/ebefbec180bb84dd192ea7d7bd4d116065975358)
- [conditionally added selected menuItem top](https://github.com/vaibhav18matere/sketchbook/commit/21fee163b5caf47ef6695ec7cbd58faa0fe1f7ff)
- [added toolbox reducers](https://github.com/vaibhav18matere/sketchbook/commit/cc0499a9faccb7c08611c3f0f192e87b408cde25)
- [color selection feature added](https://github.com/vaibhav18matere/sketchbook/commit/286bf0c8d39892f0af7fc734fb179e0f80763427)
- [color active state added dynamically](https://github.com/vaibhav18matere/sketchbook/commit/a3d91d98773321341cf6a5a7920af2d7b289f7f6)